### PR TITLE
Use `ap` in Apply instance

### DIFF
--- a/src/Control/Monad/VexceptT.purs
+++ b/src/Control/Monad/VexceptT.purs
@@ -63,14 +63,11 @@ instance functorVexceptT ∷ Functor m => Functor (VexceptT errorRows m) where
   map ∷ forall a b. (a → b) → VexceptT errorRows m a → VexceptT errorRows m b
   map f = mapVexceptT (map (map f))
 
-instance applyVexceptT ∷ Apply m => Apply (VexceptT errorRows m) where
+instance applyVexceptT ∷ Monad m => Apply (VexceptT errorRows m) where
   apply ∷ forall a b. VexceptT errorRows m (a → b) → VexceptT errorRows m a → VexceptT errorRows m b
-  apply (VexceptT mf) (VexceptT ma) = VexceptT ado
-    f <- mf
-    a <- ma
-    in apply f a
+  apply = ap
 
-instance applicativeVexceptT ∷ Applicative m => Applicative (VexceptT errorRows m) where
+instance applicativeVexceptT ∷ Monad m => Applicative (VexceptT errorRows m) where
   pure ∷ forall a. a → VexceptT errorRows m a
   pure = VexceptT <<< pure <<< pure
 


### PR DESCRIPTION
Before code like the example below would not short-circuit as expected when using traverse. Turns out the Applicative instance should be implemented differently.
```purescript
main :: Effect Unit
main = do
  void $ runVexceptT do
    for_ [ "A", "B", "C" ] \c -> do
      lift (log c)
      if c == "B" then
        vexcept $ Veither $ inj (Proxy :: Proxy "a") "NOOO B!"
      else
        lift (log ("X " <> c))
```

**Note**: this looks like a breaking change, but I'm not sure how breaking. I made this change in our codebase which uses `VexeptT` extensively and nothing broke... so far...